### PR TITLE
Add Function as valid prop type to label and icon

### DIFF
--- a/src/ContextMenuItem.vue
+++ b/src/ContextMenuItem.vue
@@ -111,14 +111,14 @@ export default defineComponent({
      * Menu label
      */
     label: {
-      type: [String, Object],
+      type: [String, Object, Function],
       default: ''
     },
     /**
      * Menu icon (for icon class)
      */
     icon: {
-      type: [String, Object],
+      type: [String, Object, Function],
       default: ''
     },
     /**


### PR DESCRIPTION
A MenuItem label or icon can be a function according to the MenuItem definitions:

```typescript
interface MenuItem { 
  label ?: string|VNode|((label: string) => VNode),
  icon ?: string|VNode|((icon: string) => VNode),
...
}
```

This commits updates the label and icon property types to remove the warning in the console when we use a function as label or icon value:

``` 
[Vue warn]: Invalid prop: type check failed for prop "label". Expected String | Object, got Function  
  at <ContextMenuItem ...
```

Example of a MenuItem definition that will trigger a warning:

```vue
const formattedPosition = computed(() =>
      getCoordinateFormatFunction(settings.coordinateFormat)(dropPosition)
    );

const menu = ref<MenuOptions>({
  items: [
    {
      label: () =>
        h(
          "div",
          { class: "text-sm text-gray-600 font-medium" },
          formattedPosition.value
        ),
      icon: h(IconMapMarker, { class: "text-gray-500" }),
      onClick: async () => {
        await copyToClipboard(formattedPosition.value);
        send({
          message: `Copied ${formattedPosition.value} to the clipboard`,
        });
      },
    },
...
]
```

I have not fully tested that this will remove the warning, but I believe so. 