### PR TITLE
fix: change the augmentation module

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,7 @@ export * from './lib';
 
 declare module 'vue3-context-menu' {
 }
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   export interface ComponentCustomProperties {
     /**
      * Show a ContextMenu .


### PR DESCRIPTION
Hello, How is going?

Vue has changed the module name to augment.

https://vuejs.org/guide/typescript/options-api#augmenting-global-properties