### PR TITLE
feat: add destroyOnClose option to context menus

### DIFF
--- a/examples/App.vue
+++ b/examples/App.vue
@@ -9,6 +9,7 @@
       <router-link :to="{ name: 'Theme' }">Themes</router-link>
       <router-link :to="{ name: 'ChangeContainer' }">Change container</router-link>
       <router-link :to="{ name: 'MenuBar' }">MenuBar</router-link>
+      <router-link :to="{ name: 'DestroyOnClose' }">DestroyOnClose</router-link>
     </div>
     <div class="test-host">
       <router-view />

--- a/examples/router/index.ts
+++ b/examples/router/index.ts
@@ -6,6 +6,7 @@ import Theme from '../views/Theme.vue'
 import ComponentCustomize from '../views/ComponentCustomize.vue'
 import MenuBar from '../views/MenuBar.vue'
 import ChangeContainer from '../views/ChangeContainer.vue'
+import DestroyOnClose from '../views/DestroyOnClose.vue'
 
 const routes: Array<RouteRecordRaw> = [
   {
@@ -42,6 +43,11 @@ const routes: Array<RouteRecordRaw> = [
     path: '/ChangeContainer',
     name: 'ChangeContainer',
     component: ChangeContainer,
+  },
+  {
+    path: '/DestroyOnClose',
+    name: 'DestroyOnClose',
+    component: DestroyOnClose,
   }
 ]
 

--- a/examples/views/DestroyOnClose.vue
+++ b/examples/views/DestroyOnClose.vue
@@ -1,0 +1,67 @@
+<template>
+  <div class="box2">
+    <h2>Component DestroyOnClose Test</h2>
+    <p>Right click the box below to see the context menu.</p>
+    <p>Check the console to see mount/unmount logs.</p>
+    <div 
+      class="box1" 
+      style="margin-top: 20px"
+      @contextmenu="onContextMenu"
+    >
+      Right click me
+    </div>
+
+    <div style="margin-top: 20px">
+      <label>
+        <input type="checkbox" v-model="destroyOnClose">
+        destroy-on-close (Default: true)
+      </label>
+    </div>
+
+    <ContextMenu
+      v-model:show="show"
+      :options="options"
+      :destroy-on-close="destroyOnClose"
+    >
+      <ContextMenuItem>
+        <TestComponent name="Menu Item 1" />
+      </ContextMenuItem>
+      <ContextMenuItem>
+        <TestComponent name="Menu Item 2" />
+      </ContextMenuItem>
+    </ContextMenu>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref, defineComponent, onMounted, onUnmounted, h } from 'vue'
+import { ContextMenu, ContextMenuItem } from '../../library/index'
+
+const show = ref(false)
+const destroyOnClose = ref(false)
+const options = ref({
+  x: 0,
+  y: 0
+})
+
+const TestComponent = defineComponent({
+  props: ['name'],
+  setup(props) {
+    onMounted(() => {
+      console.log(`[TestComponent] ${props.name} mounted`)
+    })
+    onUnmounted(() => {
+      console.log(`[TestComponent] ${props.name} unmounted`)
+    })
+    return () => h('div', props.name)
+  },
+
+})
+
+function onContextMenu(e: MouseEvent) {
+  e.preventDefault()
+  show.value = true
+  options.value.x = e.x
+  options.value.y = e.y
+}
+</script>

--- a/library/ContextMenu.vue
+++ b/library/ContextMenu.vue
@@ -4,6 +4,7 @@
       ref="menuRef"
       :options="options"
       :show="show"
+      :destroyOnClose="destroyOnClose"
       :container="container"
       :isFullScreenContainer="!isNew"
       @close="onClose"
@@ -45,9 +46,16 @@ const props = defineProps({
     type: Boolean,
     default: false
   },
+  /**
+   * Should the menu be destroyed when it is closed?
+   */
+  destroyOnClose: {
+    type: Boolean,
+    default: true
+  },
 })
 
-const { options, show } = toRefs(props);
+const { options, show, destroyOnClose } = toRefs(props);
 const { isNew, container, eleId } = genContainer(options.value);
 
 const menuRef = ref<ContextMenuInstance | null>(null);

--- a/library/ContextMenuDefine.ts
+++ b/library/ContextMenuDefine.ts
@@ -314,6 +314,12 @@ export interface MenuOptions {
    */
   minWidth ?: number;
   /**
+   * Should the menu be destroyed when it is closed? (Only for component mode)
+   * 
+   * Default: true
+   */
+  destroyOnClose ?: boolean;
+  /**
    * Close when user scroll mouse ? Default is true.
    */
   closeWhenScroll ?: boolean;

--- a/library/ContextSubMenu.vue
+++ b/library/ContextSubMenu.vue
@@ -9,7 +9,8 @@
     >
       <div
         ref="submenuRoot"
-        v-if="show"
+        v-if="!destroyOnClose || show"
+        v-show="show"
         v-bind="$attrs"
         :class="[
           'mx-context-menu',
@@ -69,6 +70,7 @@
                     <!--Sub menu-->
                     <ContextSubMenu
                       :show="show"
+                      :destroyOnClose="destroyOnClose"
                       :parentMenuItemContext="context"
                       :items="item.children"
                       :maxWidth="item.maxWidth"
@@ -168,6 +170,13 @@ const props = defineProps({
   show: {
     type: Boolean,
     default: false,
+  },
+  /**
+   * Should the menu be destroyed when it is closed?
+   */
+  destroyOnClose: {
+    type: Boolean,
+    default: true
   },
   /**
    * Max height for this submenu

--- a/library/ContextSubMenuWrapper.vue
+++ b/library/ContextSubMenuWrapper.vue
@@ -2,6 +2,7 @@
   <ContextSubMenuConstructor
     ref="submenuInstance"
     :show="show"
+    :destroyOnClose="destroyOnClose"
     :items="options.items"
     :adjustPosition="options.adjustPosition"
     :maxWidth="options.maxWidth || MenuConstOptions.defaultMaxWidth"
@@ -44,6 +45,13 @@ const props = defineProps({
     default: null
   },
   /**
+   * Should the menu be destroyed when it is closed?
+   */
+  destroyOnClose: {
+    type: Boolean,
+    default: true
+  },
+  /**
    * Current container, For calculation only
    */
   container: {
@@ -68,6 +76,7 @@ const submenuInstance = ref<ContextSubMenuInstance>();
 const {
   options,
   show,
+  destroyOnClose,
   container,
 } = toRefs(props);
 


### PR DESCRIPTION
Introduced a new `destroyOnClose` property to allow menus to remain in the DOM after being hidden. This provides better control over component lifecycle and performance when the menu needs to be reused without being re-mounted.

Key changes:
- Added `destroyOnClose` to `MenuOptions` interface and component props.
- Updated `ContextSubMenu` to use `v-show` combined with conditional `v-if` logic to support persistent DOM elements.
- Added a new example page and route to demonstrate the functionality.